### PR TITLE
Handled Date Fields such as start_date

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -2,7 +2,7 @@ import * as grpc from 'grpc';
 import * as request from 'request-promise';
 import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
-import { ContactAwareMixin } from './mixins';
+import { ContactAwareMixin, DateAwareMixin } from './mixins';
 
 class ClientWrapper {
   public static expectedAuthFields: Field[] = [{
@@ -27,8 +27,8 @@ class ClientWrapper {
 
 }
 
-interface ClientWrapper extends ContactAwareMixin {}
-applyMixins(ClientWrapper, [ContactAwareMixin]);
+interface ClientWrapper extends ContactAwareMixin, DateAwareMixin {}
+applyMixins(ClientWrapper, [ContactAwareMixin, DateAwareMixin]);
 
 function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach((baseCtor) => {

--- a/src/client/mixins/date-aware.ts
+++ b/src/client/mixins/date-aware.ts
@@ -1,0 +1,25 @@
+export class DateAwareMixin {
+  public isDate(value: any): boolean {
+    let result = false;
+    const minEpochValue = 605692800000;
+    const today = new Date();
+    const tenYearsFromNow = today.setFullYear(today.getFullYear() + 10).valueOf();
+
+    const isNumber = !isNaN(value);
+    const isEpoch = +value > minEpochValue;
+    const withinTenYears = +value < tenYearsFromNow;
+
+    result = isNumber && isEpoch && withinTenYears;
+
+    return result;
+  }
+
+  public toDate(epoch: number): string {
+    const result = new Date(+epoch);
+    return result.toISOString();
+  }
+
+  public toEpoch(date: Date): string {
+    return date.valueOf().toString();
+  }
+}

--- a/src/client/mixins/index.ts
+++ b/src/client/mixins/index.ts
@@ -1,1 +1,2 @@
 export * from './contact-aware';
+export * from './date-aware';

--- a/src/steps/contacts/contact-field-equals.ts
+++ b/src/steps/contacts/contact-field-equals.ts
@@ -75,8 +75,10 @@ export class ContactFieldEqualsStep extends BaseStep implements StepInterface {
       }
 
       // Non-existent fields should always default to `null` for `Set` operators.
-      const actualValue = contact.attributes[field]
+      const fieldValue = contact.attributes[field]
         ? contact.attributes[field] : null;
+
+      const actualValue = this.client.isDate(fieldValue) ? this.client.toDate(fieldValue) : fieldValue;
 
       const contactRecord = this.createRecord(contact);
       const result = this.assert(operator, actualValue, expectedValue, field);

--- a/test/scenarios/Contact CRUD.crank.yml
+++ b/test/scenarios/Contact CRUD.crank.yml
@@ -1,0 +1,21 @@
+scenario: Drift Contact CRUD Steps
+description: >
+  This scenario proves that contact creation, checking, and deletion steps work
+  as expected for Drift API Integration.
+
+tokens:
+  test.email: test@thisisjust.atomatest.com
+  test.name: AtomaTommy
+  test.company: Automaton Inc.
+
+steps:
+- step: Given I create or update a Drift Contact
+  data:
+    contact:
+      email: '{{test.email}}'
+      name: '{{test.name}}'
+      company: '{{test.company}}'
+- step: Then the email field on Drift Contact {{test.email}} should be set
+- step: And the company field on Drift Contact {{test.email}} should be one of {{test.company}}
+- step: And the start_date field on Drift Contact {{test.email}} should be greater than 2019-01-01
+- step: Finally, delete the {{test.email}} Drift Contact


### PR DESCRIPTION
## New
- Drift's date fields follows the UNIX Timestamp format or EPOCH. To successfully check such fields, created the `date-aware` mixin that should be able to tell, and convert such values to/from dates so that it can easily be validated by `crank`
- Added a new `Scenario File: Drift Contact API CRUD.crank.yml` that can eventually be ran by the pipeline to check integration.