### PR TITLE
Fixed naming inconsistencies found in the Dockerfile and package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY --from=build /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 COPY --from=build /app .
 COPY . .
 EXPOSE 28866
-LABEL com.automatoninc.cog-for="drift"
+LABEL com.automatoninc.cog-for="Drift"
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "node", "build/core/grpc-server.js"]


### PR DESCRIPTION
Fixed naming inconsistencies found in the Dockerfile and package.json