### PR TITLE
Replaced createdAt with start_date for contact tokens for Drift

### DIFF
--- a/src/steps/contacts/contact-create-or-update.ts
+++ b/src/steps/contacts/contact-create-or-update.ts
@@ -23,13 +23,13 @@ export class CreateOrUpdateContactStep extends BaseStep implements StepInterface
       type: FieldDefinition.Type.NUMERIC,
       description: 'The contact\'s ID',
     }, {
-      field: 'createdAt',
-      type: FieldDefinition.Type.DATETIME,
-      description: 'The Contact\'s Create Date',
-    }, {
       field: 'email',
       type: FieldDefinition.Type.EMAIL,
       description: 'The Contact\'s Email',
+    }, {
+      field: 'start_date',
+      type: FieldDefinition.Type.DATETIME,
+      description: 'The Contact\'s Create Date',
     }],
     dynamicFields: true,
   }];

--- a/src/steps/contacts/contact-delete.ts
+++ b/src/steps/contacts/contact-delete.ts
@@ -23,13 +23,13 @@ export class DeleteContactStep extends BaseStep implements StepInterface {
       type: FieldDefinition.Type.NUMERIC,
       description: 'The contact\'s ID',
     }, {
-      field: 'createdAt',
-      type: FieldDefinition.Type.DATETIME,
-      description: 'The Contact\'s Create Date',
-    }, {
       field: 'email',
       type: FieldDefinition.Type.EMAIL,
       description: 'The Contact\'s Email',
+    }, {
+      field: 'start_date',
+      type: FieldDefinition.Type.DATETIME,
+      description: 'The Contact\'s Create Date',
     }],
     dynamicFields: true,
   }];

--- a/src/steps/contacts/contact-field-equals.ts
+++ b/src/steps/contacts/contact-field-equals.ts
@@ -47,7 +47,7 @@ export class ContactFieldEqualsStep extends BaseStep implements StepInterface {
       description: "Contact's Email Address",
       type: FieldDefinition.Type.EMAIL,
     }, {
-      field: 'createdAt',
+      field: 'start_date',
       description: "Contact's Create Date",
       type: FieldDefinition.Type.DATETIME,
     }],


### PR DESCRIPTION
## Changed
1. For `expectedFields`, replaced `createdAt` with `start_date` as `createdAt` is a custom field while `start_date` is a common field that is automatically set when a Drift contact is created