### PR TITLE
Applied errors vs fails message changes to drift

### DIFF
--- a/src/steps/contacts/contact-delete.ts
+++ b/src/steps/contacts/contact-delete.ts
@@ -43,7 +43,7 @@ export class DeleteContactStep extends BaseStep implements StepInterface {
 
       // When the email is not associated with any contact, respond with error.
       if (!contact) {
-        return this.error('Contact %s was not found', [email]);
+        return this.fail('Contact %s was not found', [email]);
       }
 
       // Delete the Drift Contact.

--- a/src/steps/contacts/contact-field-equals.ts
+++ b/src/steps/contacts/contact-field-equals.ts
@@ -71,7 +71,7 @@ export class ContactFieldEqualsStep extends BaseStep implements StepInterface {
     try {
       if (!contact) {
         // If no results were found, return an error.
-        return this.error('No contact found with email %s', [email]);
+        return this.fail('No contact found with email %s', [email]);
       }
 
       // Non-existent fields should always default to `null` for `Set` operators.


### PR DESCRIPTION
Some messages that are an `Error` have been changed to `Fail`