### PR TITLE
Fixing a bug with the RunStep function

### DIFF
--- a/src/core/cog.ts
+++ b/src/core/cog.ts
@@ -207,7 +207,7 @@ export class Cog implements ICogServiceServer {
     }
 
     try {
-      const stepExecutor: StepInterface = new this.stepMap[stepId](client);
+      const stepExecutor: StepInterface = new this.stepMap[stepId](wrapper);
       response = await stepExecutor.executeStep(step);
     } catch (e) {
       response.setOutcome(RunStepResponse.Outcome.ERROR);


### PR DESCRIPTION
Fixing a bug where the client was null when running a single step.